### PR TITLE
feat(types): export types related to `createSnapshotSerializer`

### DIFF
--- a/src/createSnapshotSerializer.ts
+++ b/src/createSnapshotSerializer.ts
@@ -4,14 +4,14 @@ import {
   createPnpmInnerMatchers,
   createTmpDirMatchers,
 } from './matchers';
-import type { PathMatcher, SnapshotSerializerOptions } from './types';
 import {
-  normalizePathToPosix,
-  normalizeCodeToPosix,
   normalizeCLR,
+  normalizeCodeToPosix,
+  normalizePathToPosix,
 } from './normalize';
+import type { PathMatcher, SnapshotSerializerOptions } from './types';
 
-interface SnapshotSerializer {
+export interface SnapshotSerializer {
   serialize: (val: any) => string;
   test: (arg0: any) => boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,5 @@
+// export types related to `createSnapshotSerializer`
+export type { PathMatcher, SnapshotSerializerOptions, Features } from './types';
+export type { SnapshotSerializer } from './createSnapshotSerializer';
+
 export { createSnapshotSerializer } from './createSnapshotSerializer';


### PR DESCRIPTION
Types related to `createSnapshotSerializer` are not exported. This causes exporting methods related to the type in down-stream not being able to export as well. This PR fixes this issue.

```
Exported variable 'VARIABLE' has or is using name 'SnapshotSerializer' from external module "<PATH_TO_path-serializer>/dist/esm/index" but cannot be named.
```