### PR TITLE
fix: normalize multiple backslash `\\` win path in string

### DIFF
--- a/e2e/pnpmInnerWin32.test.ts
+++ b/e2e/pnpmInnerWin32.test.ts
@@ -39,6 +39,34 @@ test('should serialize <PNPM_INNER> with webpack path', () => {
   `);
 });
 
+test('should serialize Lynx JSX', () => {
+  const JSX = `
+function App() {
+    const value = "content 3";
+    return __RenderContent(/*#__PURE__*/ (0,_lynx_js_react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__.jsxDEV)(__snapshot_4953c_00662_1, {
+        children: value
+    }, void 0, false, {
+        fileName: "D:\\\\user\\\\rspack\\\\app.jsx",
+        lineNumber: 3,
+        columnNumber: 26
+    }, this));
+}
+`;
+
+  expect(JSX).toMatchInlineSnapshot(`
+    function App() {
+        const value = "content 3";
+        return __RenderContent(/*#__PURE__*/ (0,_lynx_js_react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__.jsxDEV)(__snapshot_4953c_00662_1, {
+            children: value
+        }, void 0, false, {
+            fileName: "<ROOT>/app.jsx",
+            lineNumber: 3,
+            columnNumber: 26
+        }, this));
+    }
+  `);
+});
+
 test('should serialize rspack diagnostic', () => {
   const posixDiagnostic = `
   File: /d/user/rspack/src/index.ts?__rslib_entry__:1:1

--- a/src/normalize.test.ts
+++ b/src/normalize.test.ts
@@ -80,6 +80,22 @@ function _class_private_method_get(receiver, privateSet, fn) {
   `);
   });
 
+  test('should serialize windows path in string', () => {
+    const code = normalizeCodeToPosix(`
+    {
+        loader: "C:\\\\user\\\\lynx-stack\\\\app.jsx",
+    }
+    `);
+
+    expect(code).toMatchInlineSnapshot(`
+      "
+          {
+              loader: "/c/user/lynx-stack/app.jsx",
+          }
+          "
+    `);
+  });
+
   test('should not transform http and https', () => {
     const code = normalizeCodeToPosix(`
     {

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -12,9 +12,9 @@ export const normalizeCodeToPosix = (code: string): string => {
   return code.replace(
     // windows absolute path
     // ignore http, https, file
-    /(?<![a-zA-Z])([a-zA-Z]:[\\/])([-\u4e00-\u9fa5\w\s.()~!@#$%^&()\[\]{}+=]+[\\/])*/g,
+    /(?<![a-zA-Z])([a-zA-Z]:[\\/]+)([-\u4e00-\u9fa5\w\s.()~!@#$%^&()\[\]{}+=]+[\\/]+)*/g,
     (match: string, _diskName: string) => {
-      return normalizePathToPosix(match);
+      return normalizePathToPosix(match.replace(/[\\]{2,}/g, '\\'));
     },
   );
 };


### PR DESCRIPTION
We are using `@rspack/test-tools` with hot snapshot cases. We are generating the following code:

```js
function App() {
    const value = "content 3";
    return __RenderContent(/*#__PURE__*/ (0,_lynx_js_react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__.jsxDEV)(__snapshot_4953c_00662_1, {
        children: value
    }, void 0, false, {
        fileName: "C:\\Users\\Admin\\colin\\lynx-stack\\packages\\webpack\\react-refresh-webpack-plugin\\test\\hotCases\\jsx\\value\\app.jsx",
        lineNumber: 3,
        columnNumber: 26
    }, this));
}
```

And the content of it would be placed in another string and normalized by `path-serializer`. And it become:

```js
function App() {
    const value = "content 3";
    return __RenderContent(/*#__PURE__*/ (0,_lynx_js_react_jsx_dev_runtime__WEBPACK_IMPORTED_MODULE_0__.jsxDEV)(__snapshot_4953c_00662_1, {
        children: value
    }, void 0, false, {
        fileName: "/c/\Users\\Admin\\colin\\lynx-stack\\packages\\webpack\\react-refresh-webpack-plugin\\test\\hotCases\\jsx\\value\\app.jsx",
        lineNumber: 3,
        columnNumber: 26
    }, this));
}
```