### PR TITLE
chore(infra): add type module and publint validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,25 @@
 {
   "name": "path-serializer",
   "version": "0.6.0",
+  "type": "module",
   "description": "path-serializer",
   "keywords": ["snapshot", "rstest", "vitest", "jest", "ci", "test"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/rspack-contrib/path-serializer.git"
+    "url": "git+https://github.com/rstackjs/path-serializer.git"
   },
   "license": "MIT",
   "author": "sooniter",
   "exports": {
     ".": {
       "types": "./dist/esm/index.d.ts",
-      "import": "./dist/esm/index.mjs",
-      "require": "./dist/cjs/index.js"
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.cjs"
     },
     "./package.json": "./package.json"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.mjs",
+  "main": "./dist/cjs/index.cjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
   "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
@@ -35,6 +36,7 @@
     "pre-commit": "npx nano-staged"
   },
   "devDependencies": {
+    "rsbuild-plugin-publint": "^0.3.4",
     "@biomejs/biome": "^1.9.4",
     "@microsoft/api-extractor": "^7.48.0",
     "@rslib/core": "0.18.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       nano-staged:
         specifier: ^0.8.0
         version: 0.8.0
+      rsbuild-plugin-publint:
+        specifier: ^0.3.4
+        version: 0.3.4(@rsbuild/core@1.7.3)
       semver:
         specifier: 7.6.3
         version: 7.6.3
@@ -220,6 +223,10 @@ packages:
 
   '@napi-rs/wasm-runtime@1.0.7':
     resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
+
+  '@publint/pack@0.1.4':
+    resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
+    engines: {node: '>=18'}
 
   '@rsbuild/core@1.7.3':
     resolution: {integrity: sha512-kI1oQvCXbQYxUvQPnDLdjSX4gFsbrFNpuUj6jXEJ7IcJ74Q+n4oeFj74/8tKerhxhe0L90m/ZQfzLeN5ORGA9w==}
@@ -599,6 +606,10 @@ packages:
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
 
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
   nano-staged@0.8.0:
     resolution: {integrity: sha512-QSEqPGTCJbkHU2yLvfY6huqYPjdBrOaTMKatO1F8nCSrkQGXeKwtCiCnsdxnuMhbg3DTVywKaeWLGCE5oJpq0g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -607,6 +618,9 @@ packages:
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
@@ -626,9 +640,17 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   pretty-ms@9.1.0:
     resolution: {integrity: sha512-o1piW0n3tgKIKCwk2vpM/vOV13zjJzvP37Ioze54YlTHE06m4tjEbzg9WsKkvTuyYln2DHjo5pY4qrZGI0otpw==}
     engines: {node: '>=18'}
+
+  publint@0.3.18:
+    resolution: {integrity: sha512-JRJFeBTrfx4qLwEuGFPk+haJOJN97KnPuK01yj+4k/Wj5BgoOK5uNsivporiqBjk2JDaslg7qJOhGRnpltGeog==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -657,6 +679,18 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  rsbuild-plugin-publint@0.3.4:
+    resolution: {integrity: sha512-0oIeQlTNRQoiyi2K5RT6C0+3q8J1HZEX66pkTtDAvmNNHiLf+YyBn2bx8S2w5T7MEVt323ULKoGV4rRROIOatQ==}
+    peerDependencies:
+      '@rsbuild/core': ^1.0.0 || ^2.0.0-0
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+
+  sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
 
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
@@ -924,6 +958,8 @@ snapshots:
       '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@publint/pack@0.1.4': {}
 
   '@rsbuild/core@1.7.3':
     dependencies:
@@ -1277,6 +1313,8 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
+  mri@1.2.0: {}
+
   nano-staged@0.8.0:
     dependencies:
       picocolors: 1.0.1
@@ -1285,6 +1323,8 @@ snapshots:
     dependencies:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
+
+  package-manager-detector@1.6.0: {}
 
   parse-ms@4.0.0: {}
 
@@ -1296,9 +1336,18 @@ snapshots:
 
   picocolors@1.0.1: {}
 
+  picocolors@1.1.1: {}
+
   pretty-ms@9.1.0:
     dependencies:
       parse-ms: 4.0.0
+
+  publint@0.3.18:
+    dependencies:
+      '@publint/pack': 0.1.4
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      sade: 1.8.1
 
   punycode@2.3.1: {}
 
@@ -1317,6 +1366,17 @@ snapshots:
     optionalDependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@22.10.1)
       typescript: 5.7.2
+
+  rsbuild-plugin-publint@0.3.4(@rsbuild/core@1.7.3):
+    dependencies:
+      picocolors: 1.1.1
+      publint: 0.3.18
+    optionalDependencies:
+      '@rsbuild/core': 1.7.3
+
+  sade@1.8.1:
+    dependencies:
+      mri: 1.2.0
 
   semver@7.5.4:
     dependencies:

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rslib/core';
+import { pluginPublint } from 'rsbuild-plugin-publint';
 
 export default defineConfig({
   lib: [
@@ -33,4 +34,5 @@ export default defineConfig({
   output: {
     target: 'node',
   },
+  plugins: [pluginPublint()],
 });


### PR DESCRIPTION
## Summary
- Add `"type": "module"` to `package.json` for proper ESM support
- Update export file extensions (`.mjs` → `.js`, `.js` → `.cjs`) to align with module type
- Add `rsbuild-plugin-publint` for package publishing validation
- Update repository URL to `rstackjs` org

## Test plan
- [ ] Verify `pnpm build` succeeds with updated config
- [ ] Verify publint passes with no errors
- [ ] Verify both ESM and CJS consumers can import the package correctly